### PR TITLE
ignore empty filter to prevent error on conditions popup

### DIFF
--- a/src/z2ui5_cl_tool_app_shlp_gen.clas.abap
+++ b/src/z2ui5_cl_tool_app_shlp_gen.clas.abap
@@ -601,6 +601,12 @@ CLASS Z2UI5_CL_TOOL_APP_SHLP_GEN IMPLEMENTATION.
 
 * ---------- Fill token ---------------------------------------------------------------------------
     LOOP AT it_filter REFERENCE INTO DATA(lr_filter).
+
+      " ignore empty filter
+      IF lr_filter->option IS INITIAL.
+        CONTINUE.
+      ENDIF.
+
       DATA(lv_value) = me->mt_mapping[ key = lr_filter->option ]-value.
       REPLACE `{LOW}`  IN lv_value WITH lr_filter->low.
       REPLACE `{HIGH}` IN lv_value WITH lr_filter->high.


### PR DESCRIPTION
Confirming empty conditions gives a CX_SY_ITAB_LINE_NOT_FOUND error. I'd suggest to just ignore it.
![grafik](https://github.com/axelmohnen/a2UI5-generic_search_hlp/assets/17437789/5e593484-4e1c-4aea-a1fd-417fe4feb440)
![grafik](https://github.com/axelmohnen/a2UI5-generic_search_hlp/assets/17437789/eb9f6e93-d165-464e-9373-48cc5eb46f9e)
![grafik](https://github.com/axelmohnen/a2UI5-generic_search_hlp/assets/17437789/9311114f-0270-43a4-a73c-02de26fa97f9)

